### PR TITLE
Add dkms support

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,8 @@
+PACKAGE_NAME="rtl8821ce"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[0]="8821ce"
+DEST_MODULE_NAME[0]="8821ce"
+MAKE="'make' all KVER=${kernelver}"
+CLEAN="'make' clean"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/net/wireless"
+AUTOINSTALL="yes"


### PR DESCRIPTION
Users should be able to install dkms package then after git clone command they can
`sudo dkms add ./rtl8821ce`

`sudo dkms install rtl8821ce/1.0`
Then it will rebuild when a new kernel is installed and be working after the reboot